### PR TITLE
TAHUB REQ FOR CONTRIBUTION - Fix `updated_at` field on `Filter` table

### DIFF
--- a/db/models/filter.go
+++ b/db/models/filter.go
@@ -11,7 +11,7 @@ type Filter struct {
 	CreatedAt time.Time `bun:",notnull,default:current_timestamp"`
 	UpdatedAt bun.NullTime `bun:",nullzero"`
 }
-
+// * NOTE the filter model has a BeforeAppendModel hook too.
 func (f *Filter) BeforeAppendModel(query bun.Query) error {
 	switch query.(type) {
 	case *bun.UpdateQuery:

--- a/db/models/relay.go
+++ b/db/models/relay.go
@@ -15,7 +15,7 @@ type Relay struct {
 	// relationship
 	Filter	   *Filter `bun:"rel:has-one,join:id=relay_id"`
 }
-
+// * NOTE this is used so that the ORM applies the updated_at field
 func (r *Relay) BeforeAppendModel(ctx context.Context, query bun.Query) error {
 	switch query.(type) {
 	case *bun.UpdateQuery:

--- a/lib/service/event.go
+++ b/lib/service/event.go
@@ -209,6 +209,8 @@ func (svc *LndhubService) RespondToNip4(ctx context.Context, rawContent string, 
 	responses[replyToUri] = "broadcast"
 	// * TODO confirm this and insert event here too
 	// update filter value
+
+	// * NOTE this is where the call occurs for the filter to be updated
 	_, filter_err := svc.UpdateRelay(ctx, replyToUri, eventTime)
 	if filter_err != nil {
 		svc.Logger.Errorf("Failed to update filter for relay %s: %v", replyToUri, err)

--- a/lib/service/relay.go
+++ b/lib/service/relay.go
@@ -21,7 +21,7 @@ func (svc *LndhubService) FindRelay(ctx context.Context, relayUri string) (*mode
 	}
 	return &relay, nil
 }
-
+// * NOTE this is the function that calls the update
 func (svc *LndhubService) UpdateRelay(ctx context.Context, relayUri string, lastSeen int64) (relay *models.Relay, err error) {
 	relay, err = svc.FindRelay(ctx, relayUri)
 	if err != nil {


### PR DESCRIPTION
**PROBLEM**: The `updated_at` field of the `Filter` table/ORM model is not working. 

**NOTES**: See commit for relevant codebase area and notes.

**Screenshot from Postgres that depicts issue:**

```
tahub=# select * from relays;
 id |               uri               |  relay_name  |          created_at           |          updated_at           
----+---------------------------------+--------------+-------------------------------+-------------------------------
  1 | wss://dev-relay.nostrassets.com | internal-dev | 2024-02-18 09:01:06.35036+00  | 
  2 | wss://relay.damus.io            | damus        | 2024-02-18 09:01:06.353585+00 | 2024-02-18 10:05:03.114841+00
(2 rows)

tahub=# select * from filters;
 relay_id | last_event_seen |          created_at           | updated_at 
----------+-----------------+-------------------------------+------------
        1 |      1708201481 | 2024-02-18 09:01:06.362776+00 | 
        2 |      1708255675 | 2024-02-18 09:01:06.36518+00  | 
(2 rows)
```